### PR TITLE
Covalence Version bump to v0.8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ common: &common
   docker:
     - image: alpine:3.7
   environment:
-    COVALENCE_VERSION: 0.8.2
+    COVALENCE_VERSION: 0.8.3
     COVALENCE_REGISTRY: 'unifio/covalence'
     TERRAFORM_VERSION: 0.11.8
 


### PR DESCRIPTION
* Updating to covalence version 0.8.3 to address issues with [sops version output handling](https://github.com/unifio/covalence/issues/72)